### PR TITLE
feat: 新增 Claude code 到 Codex 插件 manifest/marketplace 的转换及其他平台的部分功能优化，修复 Scanner 并支持 MCP 环境变量转换

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:developers.openai.com)",
+      "WebFetch(domain:cursor.com)",
+      "Bash(xargs ls:*)",
+      "WebFetch(domain:opencode.ai)",
+      "WebSearch",
+      "WebFetch(domain:gist.github.com)",
+      "WebFetch(domain:deepwiki.com)",
+      "WebFetch(domain:github.com)",
+      "Bash(npx tsc:*)",
+      "Bash(npx vitest:*)",
+      "Bash(git clone:*)"
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -901,9 +901,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -918,9 +915,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -935,9 +929,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -952,9 +943,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -969,9 +957,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -986,9 +971,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1003,9 +985,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1020,9 +999,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1037,9 +1013,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1054,9 +1027,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1071,9 +1041,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1088,9 +1055,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1105,9 +1069,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/__tests__/pluginManifest.test.ts
+++ b/src/__tests__/pluginManifest.test.ts
@@ -1,0 +1,443 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  convertPluginManifestForCodex,
+  convertPluginManifestForCursor,
+  convertMarketplaceForCodex,
+  convertMarketplaceForCursor,
+} from '../converter/pluginManifest.js';
+import { scanPlugin, scanMarketplaceMeta, readPluginMeta, analyzeSourceTarget, scanAllPlugins } from '../scanner/plugin.js';
+import { convertMCP } from '../converter/mcp.js';
+import type { PluginMeta, ScanResult, PluginScanResult, MarketplaceMeta } from '../types.js';
+
+// --- Fixtures ---
+
+let fixtureDir: string;
+let pluginWithInterface: string;
+let pluginWithCustomPaths: string;
+let marketplaceWithPluginRoot: string;
+let marketplaceWithSkillsSource: string;
+let pluginWithMCP: string;
+
+beforeAll(() => {
+  fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'acplugin-manifest-test-'));
+
+  // Plugin with full interface metadata
+  pluginWithInterface = path.join(fixtureDir, 'plugin-interface');
+  fs.mkdirSync(path.join(pluginWithInterface, '.claude-plugin'), { recursive: true });
+  fs.writeFileSync(path.join(pluginWithInterface, '.claude-plugin', 'plugin.json'), JSON.stringify({
+    name: 'my-plugin',
+    version: '0.1.0',
+    description: 'A test plugin',
+    author: { name: 'Test Author', email: 'test@example.com', url: 'https://example.com' },
+    homepage: 'https://example.com/plugin',
+    repository: 'https://github.com/test/plugin',
+    license: 'MIT',
+    keywords: ['test', 'plugin'],
+    skills: './skills/',
+    mcpServers: './.mcp.json',
+    apps: './.app.json',
+    interface: {
+      displayName: 'My Plugin',
+      shortDescription: 'Short desc',
+      longDescription: 'Long description here',
+      developerName: 'Test Team',
+      category: 'Productivity',
+      capabilities: ['Read', 'Write'],
+      websiteURL: 'https://example.com',
+      brandColor: '#10A37F',
+      logo: './assets/logo.png',
+      screenshots: ['./assets/screenshot.png'],
+    },
+  }));
+  fs.mkdirSync(path.join(pluginWithInterface, 'skills', 'hello'), { recursive: true });
+  fs.writeFileSync(path.join(pluginWithInterface, 'skills', 'hello', 'SKILL.md'),
+    '---\nname: hello\ndescription: Hello skill\n---\nHello!');
+
+  // Plugin with custom resource paths
+  pluginWithCustomPaths = path.join(fixtureDir, 'plugin-custom');
+  fs.mkdirSync(path.join(pluginWithCustomPaths, '.claude-plugin'), { recursive: true });
+  fs.writeFileSync(path.join(pluginWithCustomPaths, '.claude-plugin', 'plugin.json'), JSON.stringify({
+    name: 'custom-paths',
+    version: '1.0.0',
+    skills: './custom/skills/',
+    agents: './custom/agents/',
+    hooks: './config/hooks.json',
+  }));
+  fs.mkdirSync(path.join(pluginWithCustomPaths, 'custom', 'skills', 'my-skill'), { recursive: true });
+  fs.writeFileSync(path.join(pluginWithCustomPaths, 'custom', 'skills', 'my-skill', 'SKILL.md'),
+    '---\nname: custom-skill\ndescription: Custom path skill\n---\nCustom!');
+  fs.mkdirSync(path.join(pluginWithCustomPaths, 'custom', 'agents'), { recursive: true });
+  fs.writeFileSync(path.join(pluginWithCustomPaths, 'custom', 'agents', 'reviewer.md'),
+    '---\nname: reviewer\ndescription: Reviewer agent\n---\nReview code.');
+
+  // Marketplace with pluginRoot
+  marketplaceWithPluginRoot = path.join(fixtureDir, 'marketplace-root');
+  fs.mkdirSync(path.join(marketplaceWithPluginRoot, '.claude-plugin'), { recursive: true });
+  fs.writeFileSync(path.join(marketplaceWithPluginRoot, '.claude-plugin', 'marketplace.json'), JSON.stringify({
+    name: 'my-org-marketplace',
+    owner: { name: 'Test Org', email: 'org@test.com' },
+    metadata: {
+      description: 'Organization marketplace',
+      version: '0.1.0',
+      pluginRoot: 'plugins',
+    },
+    plugins: [
+      { name: 'devtools', source: 'devtools', description: 'Dev tools plugin' },
+      { name: 'empty-plugin', source: 'empty-plugin', description: 'No resources' },
+    ],
+  }));
+
+  // devtools plugin under plugins/ directory
+  const devtoolsDir = path.join(marketplaceWithPluginRoot, 'plugins', 'devtools');
+  fs.mkdirSync(path.join(devtoolsDir, '.claude-plugin'), { recursive: true });
+  fs.writeFileSync(path.join(devtoolsDir, '.claude-plugin', 'plugin.json'), JSON.stringify({
+    name: 'devtools', version: '1.0.0', description: 'Developer tools',
+  }));
+  fs.mkdirSync(path.join(devtoolsDir, 'skills', 'lint'), { recursive: true });
+  fs.writeFileSync(path.join(devtoolsDir, 'skills', 'lint', 'SKILL.md'),
+    '---\nname: lint\ndescription: Lint code\n---\nLint!');
+
+  // empty plugin (no resources)
+  const emptyDir = path.join(marketplaceWithPluginRoot, 'plugins', 'empty-plugin');
+  fs.mkdirSync(path.join(emptyDir, '.claude-plugin'), { recursive: true });
+  fs.writeFileSync(path.join(emptyDir, '.claude-plugin', 'plugin.json'), JSON.stringify({
+    name: 'empty-plugin',
+  }));
+
+  // Marketplace where source points directly to skills dir (flat layout like chrome-devtools-capturer-repo)
+  marketplaceWithSkillsSource = path.join(fixtureDir, 'marketplace-flat');
+  fs.mkdirSync(path.join(marketplaceWithSkillsSource, '.claude-plugin'), { recursive: true });
+  fs.writeFileSync(path.join(marketplaceWithSkillsSource, '.claude-plugin', 'marketplace.json'), JSON.stringify({
+    name: 'flat-plugin',
+    owner: { name: 'TestOwner' },
+    plugins: [
+      { name: 'my-capturer', version: '1.0.0', source: './skills', description: 'Flat skills plugin' },
+    ],
+  }));
+  fs.mkdirSync(path.join(marketplaceWithSkillsSource, 'skills', 'capture'), { recursive: true });
+  fs.writeFileSync(path.join(marketplaceWithSkillsSource, 'skills', 'capture', 'SKILL.md'),
+    '---\nname: capture\ndescription: Capture data\n---\nCapture!');
+  fs.mkdirSync(path.join(marketplaceWithSkillsSource, 'skills', 'analyze'), { recursive: true });
+  fs.writeFileSync(path.join(marketplaceWithSkillsSource, 'skills', 'analyze', 'SKILL.md'),
+    '---\nname: analyze\ndescription: Analyze data\n---\nAnalyze!');
+
+  // Plugin with .mcp.json referencing ${CLAUDE_PLUGIN_ROOT}/scripts/
+  pluginWithMCP = path.join(fixtureDir, 'plugin-mcp');
+  fs.mkdirSync(path.join(pluginWithMCP, '.claude-plugin'), { recursive: true });
+  fs.writeFileSync(path.join(pluginWithMCP, '.claude-plugin', 'plugin.json'), JSON.stringify({
+    name: 'mcp-plugin',
+    version: '1.0.0',
+  }));
+  fs.writeFileSync(path.join(pluginWithMCP, '.mcp.json'), JSON.stringify({
+    mcpServers: {
+      'my-server': {
+        command: 'node',
+        args: ['${CLAUDE_PLUGIN_ROOT}/scripts/server/start.js'],
+        env: { CONFIG: '${CLAUDE_PLUGIN_ROOT}/config/settings.json' },
+      },
+    },
+  }));
+  fs.mkdirSync(path.join(pluginWithMCP, 'scripts', 'server'), { recursive: true });
+  fs.writeFileSync(path.join(pluginWithMCP, 'scripts', 'server', 'start.js'), 'console.log("hello");');
+  fs.mkdirSync(path.join(pluginWithMCP, 'skills', 'test-skill'), { recursive: true });
+  fs.writeFileSync(path.join(pluginWithMCP, 'skills', 'test-skill', 'SKILL.md'),
+    '---\nname: test-skill\ndescription: Test\n---\nTest!');
+});
+
+// --- Tests ---
+
+describe('readPluginMeta - resource paths', () => {
+  it('extracts resource path fields from plugin.json', () => {
+    const meta = readPluginMeta(pluginWithInterface);
+    expect(meta.skills).toBe('./skills/');
+    expect(meta.mcpServers).toBe('./.mcp.json');
+    expect(meta.apps).toBe('./.app.json');
+  });
+
+  it('extracts interface metadata', () => {
+    const meta = readPluginMeta(pluginWithInterface);
+    expect(meta.interface).toBeDefined();
+    expect(meta.interface!.displayName).toBe('My Plugin');
+    expect(meta.interface!.category).toBe('Productivity');
+    expect(meta.interface!.brandColor).toBe('#10A37F');
+    expect(meta.interface!.capabilities).toEqual(['Read', 'Write']);
+  });
+
+  it('extracts custom paths', () => {
+    const meta = readPluginMeta(pluginWithCustomPaths);
+    expect(meta.skills).toBe('./custom/skills/');
+    expect(meta.agents).toBe('./custom/agents/');
+    expect(meta.hooks).toBe('./config/hooks.json');
+  });
+});
+
+describe('scanPlugin - custom paths', () => {
+  it('scans skills from custom directory', () => {
+    const result = scanPlugin(pluginWithCustomPaths);
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0].frontmatter.name).toBe('custom-skill');
+  });
+
+  it('scans agents from custom directory', () => {
+    const result = scanPlugin(pluginWithCustomPaths);
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0].frontmatter.name).toBe('reviewer');
+  });
+});
+
+describe('scanMarketplaceMeta - pluginRoot', () => {
+  it('returns full marketplace metadata with pluginRoot', () => {
+    const meta = scanMarketplaceMeta(marketplaceWithPluginRoot);
+    expect(meta).not.toBeNull();
+    expect(meta!.name).toBe('my-org-marketplace');
+    expect(meta!.metadata?.pluginRoot).toBe('plugins');
+    expect(meta!.owner?.name).toBe('Test Org');
+    expect(meta!.plugins).toHaveLength(2);
+  });
+});
+
+describe('convertPluginManifestForCodex', () => {
+  it('generates .codex-plugin/plugin.json with full metadata', () => {
+    const scan = scanPlugin(pluginWithInterface);
+    const result = convertPluginManifestForCodex(scan, scan.meta);
+
+    expect(result.path).toBe('.codex-plugin/plugin.json');
+    expect(result.type).toBe('manifest');
+
+    const manifest = JSON.parse(result.content);
+    expect(manifest.name).toBe('my-plugin');
+    expect(manifest.version).toBe('0.1.0');
+    expect(manifest.author.name).toBe('Test Author');
+    expect(manifest.skills).toBe('./.agents/skills/');
+    expect(manifest.interface.displayName).toBe('My Plugin');
+    expect(manifest.interface.category).toBe('Productivity');
+    expect(manifest.interface.brandColor).toBe('#10A37F');
+  });
+
+  it('includes apps path when present in meta', () => {
+    const scan = scanPlugin(pluginWithInterface);
+    const result = convertPluginManifestForCodex(scan, scan.meta);
+    const manifest = JSON.parse(result.content);
+    expect(manifest.apps).toBe('./.app.json');
+  });
+});
+
+describe('convertPluginManifestForCursor', () => {
+  it('generates .cursor-plugin/plugin.json with interface fields', () => {
+    const scan = scanPlugin(pluginWithInterface);
+    const result = convertPluginManifestForCursor(scan, scan.meta);
+
+    expect(result.path).toBe('.cursor-plugin/plugin.json');
+
+    const manifest = JSON.parse(result.content);
+    expect(manifest.name).toBe('my-plugin');
+    expect(manifest.displayName).toBe('My Plugin');
+    expect(manifest.logo).toBe('./assets/logo.png');
+    expect(manifest.skills).toBe('./skills/');
+  });
+
+  it('falls back to interface.displayName when no top-level displayName', () => {
+    const scan: ScanResult = {
+      skills: [], instructions: [], mcp: null, agents: [], commands: [], hooks: null, pluginFiles: [],
+      rootDir: '/tmp',
+    };
+    const meta: PluginMeta = {
+      name: 'test',
+      interface: { displayName: 'From Interface' },
+    };
+    const result = convertPluginManifestForCursor(scan, meta);
+    const manifest = JSON.parse(result.content);
+    expect(manifest.displayName).toBe('From Interface');
+  });
+});
+
+describe('convertMarketplaceForCodex', () => {
+  it('generates Codex marketplace.json with policy defaults', () => {
+    const marketplace: MarketplaceMeta = {
+      name: 'test-marketplace',
+      metadata: { description: 'Test marketplace' },
+      plugins: [
+        { name: 'plugin-a', source: './plugins/plugin-a', description: 'Plugin A' },
+      ],
+    };
+    const pluginScans: PluginScanResult[] = [{
+      meta: { name: 'plugin-a', description: 'Plugin A', category: 'Productivity' },
+      skills: [{ dirName: 'skill', frontmatter: { name: 'skill' }, body: '', sourcePath: '', auxFiles: [] }],
+      instructions: [], mcp: null, agents: [], commands: [], hooks: null, pluginFiles: [], rootDir: '/tmp',
+    }];
+
+    const result = convertMarketplaceForCodex(marketplace, pluginScans);
+    expect(result.path).toBe('.agents/plugins/marketplace.json');
+
+    const output = JSON.parse(result.content);
+    expect(output.name).toBe('test-marketplace');
+    expect(output.plugins).toHaveLength(1);
+    expect(output.plugins[0].source).toEqual({ source: 'local', path: './plugins/plugin-a' });
+    expect(output.plugins[0].policy).toEqual({
+      installation: 'AVAILABLE',
+      authentication: 'ON_INSTALL',
+    });
+    expect(output.plugins[0].category).toBe('Productivity');
+  });
+});
+
+describe('convertMarketplaceForCursor', () => {
+  it('generates Cursor marketplace.json with pluginRoot', () => {
+    const marketplace: MarketplaceMeta = {
+      name: 'my-org',
+      owner: { name: 'Test Org', email: 'org@test.com' },
+      metadata: { description: 'Org marketplace', version: '0.1.0', pluginRoot: 'plugins' },
+      plugins: [
+        { name: 'devtools', source: 'devtools', description: 'Dev tools' },
+      ],
+    };
+    const pluginScans: PluginScanResult[] = [{
+      meta: { name: 'devtools', description: 'Dev tools' },
+      skills: [{ dirName: 'skill', frontmatter: { name: 'skill' }, body: '', sourcePath: '', auxFiles: [] }],
+      instructions: [], mcp: null, agents: [], commands: [], hooks: null, pluginFiles: [], rootDir: '/tmp',
+    }];
+
+    const result = convertMarketplaceForCursor(marketplace, pluginScans);
+    expect(result.path).toBe('.cursor-plugin/marketplace.json');
+
+    const output = JSON.parse(result.content);
+    expect(output.name).toBe('my-org');
+    expect(output.owner.name).toBe('Test Org');
+    expect(output.metadata.pluginRoot).toBe('plugins');
+    expect(output.plugins[0].source).toBe('devtools');
+  });
+});
+
+// --- Source target analysis ---
+
+describe('analyzeSourceTarget', () => {
+  it('detects plugin root by .claude-plugin/plugin.json', () => {
+    expect(analyzeSourceTarget(pluginWithInterface)).toBe('plugin-root');
+  });
+
+  it('detects plugin root by skills/ subdirectory', () => {
+    // marketplaceWithPluginRoot/plugins/devtools has skills/ subdir
+    const devtoolsDir = path.join(marketplaceWithPluginRoot, 'plugins', 'devtools');
+    expect(analyzeSourceTarget(devtoolsDir)).toBe('plugin-root');
+  });
+
+  it('detects skills directory by name', () => {
+    const skillsDir = path.join(marketplaceWithSkillsSource, 'skills');
+    expect(analyzeSourceTarget(skillsDir)).toBe('skills-dir');
+  });
+
+  it('returns unknown for empty directory', () => {
+    const emptyDir = path.join(fixtureDir, 'empty-dir');
+    fs.mkdirSync(emptyDir, { recursive: true });
+    expect(analyzeSourceTarget(emptyDir)).toBe('unknown');
+  });
+});
+
+describe('scanAllPlugins - flat layout (source: "./skills")', () => {
+  it('scans skills when source points directly to skills dir', () => {
+    const results = scanAllPlugins(marketplaceWithSkillsSource);
+    expect(results).toHaveLength(1);
+    expect(results[0].meta.name).toBe('my-capturer');
+    expect(results[0].skills).toHaveLength(2);
+    expect(results[0].skills.map(s => s.frontmatter.name).sort()).toEqual(['analyze', 'capture']);
+  });
+
+  it('preserves metadata from marketplace entry', () => {
+    const results = scanAllPlugins(marketplaceWithSkillsSource);
+    expect(results[0].meta.description).toBe('Flat skills plugin');
+    expect(results[0].meta.version).toBe('1.0.0');
+  });
+});
+
+// --- MCP scanning and plugin-level files ---
+
+describe('scanPlugin - MCP support', () => {
+  it('scans .mcp.json from plugin directory', () => {
+    const result = scanPlugin(pluginWithMCP);
+    expect(result.mcp).not.toBeNull();
+    expect(result.mcp!.servers).toHaveLength(1);
+    expect(result.mcp!.servers[0].name).toBe('my-server');
+    expect(result.mcp!.servers[0].command).toBe('node');
+    expect(result.mcp!.servers[0].args![0]).toContain('${CLAUDE_PLUGIN_ROOT}');
+  });
+
+  it('scans plugin-level resource files referenced by MCP', () => {
+    const result = scanPlugin(pluginWithMCP);
+    expect(result.pluginFiles.length).toBeGreaterThan(0);
+    const scriptFile = result.pluginFiles.find(f => f.relativePath.includes('start.js'));
+    expect(scriptFile).toBeDefined();
+    expect(scriptFile!.content).toBe('console.log("hello");');
+  });
+
+  it('still scans skills alongside MCP', () => {
+    const result = scanPlugin(pluginWithMCP);
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0].frontmatter.name).toBe('test-skill');
+  });
+});
+
+describe('MCP converter - ${CLAUDE_PLUGIN_ROOT} transformation', () => {
+  it('transforms args for Codex', () => {
+    const mcp = {
+      servers: [{
+        name: 'test',
+        command: 'node',
+        args: ['${CLAUDE_PLUGIN_ROOT}/scripts/server/start.js'],
+      }],
+      sourcePath: '/tmp/.mcp.json',
+    };
+    const result = convertMCP(mcp, 'codex');
+    expect(result.content).not.toContain('CLAUDE_PLUGIN_ROOT');
+    expect(result.content).toContain('./scripts/server/start.js');
+  });
+
+  it('transforms env values for Cursor', () => {
+    const mcp = {
+      servers: [{
+        name: 'test',
+        command: 'node',
+        args: ['${CLAUDE_PLUGIN_ROOT}/scripts/start.js'],
+        env: { CONFIG: '${CLAUDE_PLUGIN_ROOT}/config/settings.json' },
+      }],
+      sourcePath: '/tmp/.mcp.json',
+    };
+    const result = convertMCP(mcp, 'cursor');
+    const parsed = JSON.parse(result.content);
+    const server = parsed.mcpServers.test;
+    expect(server.args[0]).toBe('./scripts/start.js');
+    expect(server.env.CONFIG).toBe('./config/settings.json');
+  });
+
+  it('transforms for OpenCode', () => {
+    const mcp = {
+      servers: [{
+        name: 'test',
+        command: 'node',
+        args: ['${CLAUDE_PLUGIN_ROOT}/scripts/start.js'],
+      }],
+      sourcePath: '/tmp/.mcp.json',
+    };
+    const result = convertMCP(mcp, 'opencode');
+    const parsed = JSON.parse(result.content);
+    expect(parsed.mcp.test.args[0]).toBe('./scripts/start.js');
+  });
+
+  it('handles bare ${CLAUDE_PLUGIN_ROOT} without trailing path', () => {
+    const mcp = {
+      servers: [{
+        name: 'test',
+        command: 'node',
+        args: ['${CLAUDE_PLUGIN_ROOT}'],
+        env: { ROOT: '${CLAUDE_PLUGIN_ROOT}' },
+      }],
+      sourcePath: '/tmp/.mcp.json',
+    };
+    const result = convertMCP(mcp, 'cursor');
+    const parsed = JSON.parse(result.content);
+    expect(parsed.mcpServers.test.args[0]).toBe('.');
+    expect(parsed.mcpServers.test.env.ROOT).toBe('.');
+  });
+});

--- a/src/converter/mcp.ts
+++ b/src/converter/mcp.ts
@@ -1,5 +1,28 @@
-import type { MCPConfig, MCPServer, Platform, ConvertedFile } from '../types.js';
+import type { MCPConfig, Platform, ConvertedFile } from '../types.js';
 import { toToml } from '../utils/toml.js';
+
+/**
+ * Replace ${CLAUDE_PLUGIN_ROOT} with relative path.
+ * All target platforms use relative paths from plugin root.
+ */
+function transformPluginRootPaths(value: string): string {
+  return value
+    .replace(/"\$\{CLAUDE_PLUGIN_ROOT\}\/([^"]+)"/g, './$1')
+    .replace(/\$\{CLAUDE_PLUGIN_ROOT\}\//g, './')
+    .replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, '.');
+}
+
+function transformArgs(args: string[]): string[] {
+  return args.map(a => transformPluginRootPaths(a));
+}
+
+function transformEnv(env: Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    result[k] = transformPluginRootPaths(v);
+  }
+  return result;
+}
 
 export function convertMCP(mcp: MCPConfig, platform: Platform): ConvertedFile {
   switch (platform) {
@@ -28,11 +51,11 @@ function convertToCodex(mcp: MCPConfig): ConvertedFile {
       }
     } else {
       if (server.command) config.command = server.command;
-      if (server.args) config.args = server.args;
+      if (server.args) config.args = transformArgs(server.args);
     }
 
     if (server.env && Object.keys(server.env).length > 0) {
-      config.env = server.env;
+      config.env = transformEnv(server.env);
     }
 
     config.enabled = true;
@@ -61,8 +84,8 @@ function convertToOpenCode(mcp: MCPConfig): ConvertedFile {
       mcpConfig[server.name] = {
         type: 'local',
         command: server.command,
-        args: server.args || [],
-        ...(server.env && Object.keys(server.env).length > 0 ? { env: server.env } : {}),
+        args: transformArgs(server.args || []),
+        ...(server.env && Object.keys(server.env).length > 0 ? { env: transformEnv(server.env) } : {}),
       };
     }
   }
@@ -87,9 +110,9 @@ function convertToCursor(mcp: MCPConfig): ConvertedFile {
       if (server.headers) config.headers = server.headers;
     } else {
       if (server.command) config.command = server.command;
-      if (server.args) config.args = server.args;
+      if (server.args) config.args = transformArgs(server.args);
       if (server.env && Object.keys(server.env).length > 0) {
-        config.env = server.env;
+        config.env = transformEnv(server.env);
       }
     }
 
@@ -116,9 +139,9 @@ function convertToAntigravity(mcp: MCPConfig): ConvertedFile {
       if (server.headers) config.headers = server.headers;
     } else {
       if (server.command) config.command = server.command;
-      if (server.args) config.args = server.args;
+      if (server.args) config.args = transformArgs(server.args);
       if (server.env && Object.keys(server.env).length > 0) {
-        config.env = server.env;
+        config.env = transformEnv(server.env);
       }
     }
 

--- a/src/converter/pluginManifest.ts
+++ b/src/converter/pluginManifest.ts
@@ -1,0 +1,232 @@
+import type {
+  PluginMeta,
+  PluginInterface,
+  MarketplaceMeta,
+  ConvertedFile,
+  ScanResult,
+  PluginScanResult,
+  PlatformPaths,
+} from '../types.js';
+
+// ─── Platform resource paths (single source of truth) ───
+// These must match the actual output paths in each platform's writer/converter.
+//
+// Only codex and cursor support plugin manifest/marketplace generation.
+// OpenCode's plugin system is fundamentally different (npm packages / .ts modules).
+// Antigravity does not support plugins.
+// Other platforms still perform normal resource conversion (skills, agents, etc.).
+
+type ManifestPlatform = 'codex' | 'cursor';
+
+const PLATFORM_PATHS: Record<ManifestPlatform, PlatformPaths> = {
+  codex: {
+    pluginJson: '.codex-plugin/plugin.json',
+    marketplaceJson: '.agents/plugins/marketplace.json',
+    skills: './.agents/skills/',
+    agents: './.codex/agents/',
+    mcp: './.codex/config.toml',
+  },
+  cursor: {
+    pluginJson: '.cursor-plugin/plugin.json',
+    marketplaceJson: '.cursor-plugin/marketplace.json',
+    skills: './skills/',
+    agents: './agents/',
+    commands: './commands/',
+    instructions: './rules/',
+    mcp: './mcp.json',
+    hooks: './hooks/hooks-cursor.json',
+  },
+};
+
+export { PLATFORM_PATHS, type ManifestPlatform };
+
+// ─── Codex ───
+
+/**
+ * Generate .codex-plugin/plugin.json manifest from Claude plugin metadata.
+ */
+export function convertPluginManifestForCodex(
+  scan: ScanResult,
+  meta?: PluginMeta,
+): ConvertedFile {
+  const manifest: Record<string, unknown> = {
+    name: meta?.name || 'converted-plugin',
+    version: meta?.version || '1.0.0',
+    description: meta?.description || 'Converted from Claude Code plugin via acplugin',
+  };
+
+  if (meta?.author) manifest.author = meta.author;
+  if (meta?.homepage) manifest.homepage = meta.homepage;
+  if (meta?.repository) manifest.repository = meta.repository;
+  if (meta?.license) manifest.license = meta.license;
+  if (meta?.keywords) manifest.keywords = meta.keywords;
+
+  const paths = PLATFORM_PATHS.codex;
+
+  // Resource path references (derived from platform paths)
+  if (scan.skills.length > 0 && paths.skills) manifest.skills = paths.skills;
+  if (scan.mcp && paths.mcp) manifest.mcpServers = paths.mcp;
+  if (meta?.apps) manifest.apps = './.app.json';
+
+  // Interface (marketplace display metadata)
+  if (meta?.interface) {
+    manifest.interface = buildCodexInterface(meta.interface);
+  }
+
+  return {
+    path: paths.pluginJson,
+    content: JSON.stringify(manifest, null, 2),
+    type: 'manifest',
+  };
+}
+
+function buildCodexInterface(iface: PluginInterface): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  if (iface.displayName) result.displayName = iface.displayName;
+  if (iface.shortDescription) result.shortDescription = iface.shortDescription;
+  if (iface.longDescription) result.longDescription = iface.longDescription;
+  if (iface.developerName) result.developerName = iface.developerName;
+  if (iface.category) result.category = iface.category;
+  if (iface.capabilities) result.capabilities = iface.capabilities;
+  if (iface.websiteURL) result.websiteURL = iface.websiteURL;
+  if (iface.privacyPolicyURL) result.privacyPolicyURL = iface.privacyPolicyURL;
+  if (iface.termsOfServiceURL) result.termsOfServiceURL = iface.termsOfServiceURL;
+  if (iface.defaultPrompt) result.defaultPrompt = iface.defaultPrompt;
+  if (iface.brandColor) result.brandColor = iface.brandColor;
+  if (iface.composerIcon) result.composerIcon = iface.composerIcon;
+  if (iface.logo) result.logo = iface.logo;
+  if (iface.screenshots) result.screenshots = iface.screenshots;
+  return result;
+}
+
+/**
+ * Generate Codex marketplace.json from Claude marketplace metadata.
+ */
+export function convertMarketplaceForCodex(
+  marketplace: MarketplaceMeta,
+  plugins: PluginScanResult[],
+): ConvertedFile {
+  const paths = PLATFORM_PATHS.codex;
+  const output: Record<string, unknown> = {
+    name: marketplace.name,
+  };
+
+  // Interface with displayName
+  const displayName = marketplace.metadata?.description || marketplace.name;
+  output.interface = { displayName };
+
+  output.plugins = plugins.map((p) => {
+    const entry: Record<string, unknown> = {
+      name: p.meta.name,
+      source: {
+        source: 'local',
+        path: `./plugins/${p.meta.name}`,
+      },
+      policy: {
+        installation: 'AVAILABLE',
+        authentication: 'ON_INSTALL',
+      },
+    };
+    const category = p.meta.category || p.meta.interface?.category;
+    if (category) entry.category = category;
+    return entry;
+  });
+
+  return {
+    path: paths.marketplaceJson!,
+    content: JSON.stringify(output, null, 2),
+    type: 'manifest',
+  };
+}
+
+// ─── Cursor ───
+
+/**
+ * Generate .cursor-plugin/plugin.json manifest from Claude plugin metadata.
+ * Enhanced version that includes interface fields.
+ */
+export function convertPluginManifestForCursor(
+  scan: ScanResult,
+  meta?: PluginMeta,
+): ConvertedFile {
+  const manifest: Record<string, unknown> = {
+    name: meta?.name || 'converted-plugin',
+  };
+
+  if (meta?.displayName) manifest.displayName = meta.displayName;
+  // Also pull displayName from interface if not at top level
+  if (!manifest.displayName && meta?.interface?.displayName) {
+    manifest.displayName = meta.interface.displayName;
+  }
+
+  manifest.description = meta?.description || 'Converted from Claude Code plugin via acplugin';
+  manifest.version = meta?.version || '1.0.0';
+
+  if (meta?.author) manifest.author = meta.author;
+  if (meta?.homepage) manifest.homepage = meta.homepage;
+  if (meta?.repository) manifest.repository = meta.repository;
+  if (meta?.license) manifest.license = meta.license;
+  if (meta?.keywords) manifest.keywords = meta.keywords;
+
+  const paths = PLATFORM_PATHS.cursor;
+
+  // Resource paths for existing components (derived from platform paths)
+  if (scan.skills.length > 0 && paths.skills) manifest.skills = paths.skills;
+  if (scan.agents.length > 0 && paths.agents) manifest.agents = paths.agents;
+  if (scan.commands.length > 0 && paths.commands) manifest.commands = paths.commands;
+  if (scan.instructions.length > 0 && paths.instructions) manifest.rules = paths.instructions;
+  if (scan.mcp && paths.mcp) manifest.mcpServers = paths.mcp;
+  if (scan.hooks && paths.hooks) manifest.hooks = paths.hooks;
+
+  // Logo from interface
+  if (meta?.interface?.logo) manifest.logo = meta.interface.logo;
+
+  return {
+    path: paths.pluginJson,
+    content: JSON.stringify(manifest, null, 2),
+    type: 'manifest',
+  };
+}
+
+/**
+ * Generate Cursor marketplace.json from Claude marketplace metadata.
+ */
+export function convertMarketplaceForCursor(
+  marketplace: MarketplaceMeta,
+  plugins: PluginScanResult[],
+): ConvertedFile {
+  const output: Record<string, unknown> = {
+    name: marketplace.name,
+  };
+
+  if (marketplace.owner) output.owner = marketplace.owner;
+
+  // Metadata block
+  const metadata: Record<string, unknown> = {};
+  if (marketplace.metadata?.description || marketplace.description) {
+    metadata.description = marketplace.metadata?.description || marketplace.description;
+  }
+  if (marketplace.metadata?.version || marketplace.version) {
+    metadata.version = marketplace.metadata?.version || marketplace.version;
+  }
+  metadata.pluginRoot = 'plugins';
+  output.metadata = metadata;
+
+  output.plugins = plugins.map((p) => ({
+    name: p.meta.name,
+    source: p.meta.name,
+    description: p.meta.description,
+  }));
+
+  return {
+    path: PLATFORM_PATHS.cursor.marketplaceJson!,
+    content: JSON.stringify(output, null, 2),
+    type: 'manifest',
+  };
+}
+
+// OpenCode and Antigravity are intentionally not handled here.
+// OpenCode's plugin system uses npm packages / local .ts modules (fundamentally different).
+// Antigravity does not support plugins.
+// Both platforms still perform normal resource conversion (skills, agents, MCP, etc.)
+// through their respective writers.

--- a/src/github.ts
+++ b/src/github.ts
@@ -68,14 +68,59 @@ export function parseGitHubSource(source: string): GitHubSource {
 }
 
 /**
- * Download a GitHub repo tarball and extract to a temp directory.
- * Returns the path to the extracted directory.
+ * Download a GitHub repo to a temp directory.
+ * Prefers `git clone --recurse-submodules` (handles submodules properly).
+ * Falls back to tarball download if git is unavailable.
+ * Returns the path to the extracted/cloned directory.
  */
 export async function downloadGitHubRepo(source: GitHubSource): Promise<string> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'acplugin-'));
+
+  // Try git clone first (supports submodules)
+  if (isGitAvailable()) {
+    return cloneWithGit(source, tmpDir);
+  }
+
+  // Fallback: tarball download (no submodule support)
+  return downloadTarball(source, tmpDir);
+}
+
+function isGitAvailable(): boolean {
+  try {
+    execSync('git --version', { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function cloneWithGit(source: GitHubSource, tmpDir: string): string {
+  const repoUrl = `https://github.com/${source.owner}/${source.repo}.git`;
+  const cloneDir = path.join(tmpDir, source.repo);
+
+  const args = ['clone', '--depth', '1', '--recurse-submodules', '--shallow-submodules'];
+  if (source.branch) {
+    args.push('--branch', source.branch);
+  }
+  args.push(repoUrl, cloneDir);
+
+  execSync(`git ${args.join(' ')}`, { stdio: 'pipe' });
+
+  let repoDir = cloneDir;
+  if (source.subPath) {
+    const subDir = path.join(repoDir, source.subPath);
+    if (!fs.existsSync(subDir)) {
+      throw new Error(`Sub-path "${source.subPath}" not found in repository`);
+    }
+    repoDir = subDir;
+  }
+
+  return repoDir;
+}
+
+async function downloadTarball(source: GitHubSource, tmpDir: string): Promise<string> {
   const branch = source.branch || 'HEAD';
   const tarballUrl = `https://api.github.com/repos/${source.owner}/${source.repo}/tarball/${branch}`;
-
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'acplugin-'));
   const tarballPath = path.join(tmpDir, 'repo.tar.gz');
 
   // Download tarball (follow redirects)

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { Command } from 'commander';
 import * as path from 'path';
 import * as fs from 'fs';
 import { scanClaudeProject } from './scanner/claude.js';
-import { hasMarketplace, isSinglePlugin, scanAllPlugins, scanPlugin, countResources } from './scanner/plugin.js';
+import { hasMarketplace, isSinglePlugin, scanAllPlugins, scanPlugin, countResources, scanMarketplaceFull } from './scanner/plugin.js';
 import { generateCodex } from './writer/codex.js';
 import { generateOpenCode } from './writer/opencode.js';
 import { generateCursor } from './writer/cursor.js';
@@ -12,7 +12,10 @@ import { generateAntigravity } from './writer/antigravity.js';
 import { writeFile } from './utils/fs.js';
 import { parseGitHubSource, downloadGitHubRepo, cleanupTempDir, getTempRoot } from './github.js';
 import { selectPlugins, selectPlatforms, runWizard, log } from './tui.js';
-import type { Platform, ConvertResult, ScanResult, PluginScanResult } from './types.js';
+import type { Platform, ConvertResult, ScanResult, PluginScanResult, MarketplaceScanResult } from './types.js';
+import { convertMarketplaceForCodex } from './converter/pluginManifest.js';
+// TODO: re-enable after Cursor marketplace test validation
+// import { convertMarketplaceForCursor } from './converter/pluginManifest.js';
 
 const program = new Command();
 
@@ -56,12 +59,17 @@ async function resolveSource(source: string, subPath?: string): Promise<[string,
 /**
  * Detect source type and scan.
  */
-function detectAndScan(rootDir: string): { type: 'marketplace'; plugins: PluginScanResult[] }
+function detectAndScan(rootDir: string): { type: 'marketplace'; plugins: PluginScanResult[]; marketplaceMeta: MarketplaceScanResult | null }
   | { type: 'plugin'; scan: PluginScanResult }
   | { type: 'project'; scan: ScanResult } {
 
   if (hasMarketplace(rootDir)) {
-    return { type: 'marketplace', plugins: scanAllPlugins(rootDir) };
+    const full = scanMarketplaceFull(rootDir);
+    return {
+      type: 'marketplace',
+      plugins: full?.plugins || scanAllPlugins(rootDir),
+      marketplaceMeta: full,
+    };
   }
   if (isSinglePlugin(rootDir)) {
     return { type: 'plugin', scan: scanPlugin(rootDir) };
@@ -133,9 +141,10 @@ program
 
       const dryRun = opts.dryRun || false;
       const detected = detectAndScan(rootDir);
+      console.log('detected: ', JSON.stringify(detected));
 
       if (detected.type === 'marketplace') {
-        await convertMarketplace(detected.plugins, platforms, outputDir, dryRun, opts.all || false);
+        await convertMarketplace(detected.plugins, platforms, outputDir, dryRun, opts.all || false, detected.marketplaceMeta);
       } else if (detected.type === 'plugin') {
         log.header(detected.scan.meta.name);
         convertSingleScan(detected.scan, platforms, outputDir, dryRun);
@@ -155,6 +164,7 @@ async function convertMarketplace(
   outputDir: string,
   dryRun: boolean,
   all: boolean,
+  marketplaceMeta?: MarketplaceScanResult | null,
 ): Promise<void> {
   if (plugins.length === 0) {
     log.warn('No plugins with convertible resources found.');
@@ -187,13 +197,37 @@ async function convertMarketplace(
   log.info(`Converting ${selectedIndices.length} plugin(s) to ${platforms.join(', ')}...`);
 
   let totalFiles = 0;
-  for (const idx of selectedIndices) {
-    const plugin = plugins[idx];
+  const selectedPlugins = selectedIndices.map(i => plugins[i]);
+
+  for (const plugin of selectedPlugins) {
     const pluginOutputDir = useSubDirs
       ? path.join(outputDir, plugin.meta.name)
       : outputDir;
     log.header(plugin.meta.name);
     totalFiles += convertSingleScan(plugin, platforms, pluginOutputDir, dryRun);
+  }
+
+  // Generate marketplace manifest files for each platform
+  if (marketplaceMeta?.marketplace) {
+    for (const platform of platforms) {
+      const marketplaceFiles = generateMarketplaceManifest(
+        platform,
+        marketplaceMeta.marketplace,
+        selectedPlugins,
+      );
+      for (const file of marketplaceFiles.files) {
+        if (!dryRun) {
+          writeFile(path.join(outputDir, file.path), file.content);
+        }
+        totalFiles++;
+      }
+      if (marketplaceFiles.files.length > 0) {
+        log.stat(`${platform} marketplace`, `${marketplaceFiles.files.length} file(s)`);
+      }
+      for (const w of marketplaceFiles.warnings) {
+        log.warn(w);
+      }
+    }
   }
 
   console.log();
@@ -246,6 +280,32 @@ function generateForPlatform(scan: ScanResult, platform: Platform): ConvertResul
     case 'cursor': return generateCursor(scan);
     case 'antigravity': return generateAntigravity(scan);
   }
+}
+
+/**
+ * Generate marketplace manifest files for a target platform.
+ */
+function generateMarketplaceManifest(
+  platform: Platform,
+  marketplace: import('./types.js').MarketplaceMeta,
+  plugins: PluginScanResult[],
+): { files: import('./types.js').ConvertedFile[]; warnings: string[] } {
+  const files: import('./types.js').ConvertedFile[] = [];
+  const warnings: string[] = [];
+
+  switch (platform) {
+    case 'codex':
+      files.push(convertMarketplaceForCodex(marketplace, plugins));
+      break;
+    // TODO: Cursor marketplace generation — pending test validation
+    // case 'cursor':
+    //   files.push(convertMarketplaceForCursor(marketplace, plugins));
+    //   break;
+    // OpenCode and Antigravity don't support plugin manifest/marketplace.
+    // Their resource conversion (skills, agents, etc.) is handled normally by the writers.
+  }
+
+  return { files, warnings };
 }
 
 // --- Print functions ---

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -14,6 +14,7 @@ export function scanClaudeProject(rootDir: string): ScanResult {
     agents: scanAgentsDir(path.join(rootDir, '.claude', 'agents')),
     commands: scanCommandsDir(path.join(rootDir, '.claude', 'commands')),
     hooks: scanSettingsHooks(path.join(rootDir, '.claude', 'settings.json')),
+    pluginFiles: [],
     rootDir,
   };
 }

--- a/src/scanner/plugin.ts
+++ b/src/scanner/plugin.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
-import { readFile, fileExists } from '../utils/fs.js';
-import { scanSkillsDir, scanAgentsDir, scanCommandsDir, scanHooksJson } from './claude.js';
-import type { PluginMeta, PluginScanResult } from '../types.js';
+import { readFile, fileExists, listDirs, listFilesRecursive } from '../utils/fs.js';
+import { scanSkillsDir, scanAgentsDir, scanCommandsDir, scanHooksJson, scanMCPJson } from './claude.js';
+import type { PluginMeta, PluginScanResult, MarketplaceMeta, MarketplaceScanResult, MCPConfig, PluginResourceFile } from '../types.js';
 
 /**
  * Check if a directory contains a Claude Code plugin marketplace.
@@ -18,66 +18,117 @@ export function isSinglePlugin(rootDir: string): boolean {
 }
 
 /**
- * Scan marketplace.json and return plugin metadata with resolved paths.
+ * Scan marketplace.json and return full marketplace metadata.
  */
-export function scanMarketplace(rootDir: string): PluginMeta[] {
+export function scanMarketplaceMeta(rootDir: string): MarketplaceMeta | null {
   const marketplacePath = path.join(rootDir, '.claude-plugin', 'marketplace.json');
   const content = readFile(marketplacePath);
-  if (!content) return [];
+  if (!content) return null;
 
   try {
     const data = JSON.parse(content);
-    const plugins: PluginMeta[] = (data.plugins || []).map((p: any) => ({
-      name: p.name,
-      description: p.description,
-      version: p.version,
-      author: p.author,
-      source: p.source,
-      category: p.category,
-      displayName: p.displayName,
-      homepage: p.homepage,
-      repository: p.repository,
-      license: p.license,
-      keywords: p.keywords,
-    }));
-    return plugins;
+    return {
+      name: data.name || 'marketplace',
+      version: data.version,
+      description: data.description,
+      owner: data.owner,
+      metadata: data.metadata,
+      plugins: (data.plugins || []).map((p: any) => ({
+        name: p.name,
+        source: p.source,
+        description: p.description,
+        version: p.version,
+        category: p.category,
+      })),
+    };
   } catch {
-    return [];
+    return null;
   }
 }
 
 /**
- * Resolve the actual directory path for a plugin from its marketplace source field.
+ * Scan marketplace.json and return plugin metadata with resolved paths.
  */
-export function resolvePluginDir(rootDir: string, source: string): string {
-  // source is like "./plugins/code-review"
+export function scanMarketplace(rootDir: string): PluginMeta[] {
+  const marketplace = scanMarketplaceMeta(rootDir);
+  if (!marketplace) return [];
+
+  return marketplace.plugins.map((p) => ({
+    name: p.name,
+    description: p.description,
+    version: p.version,
+    source: p.source,
+    category: p.category,
+  }));
+}
+
+/**
+ * Resolve the actual directory path for a plugin from its marketplace source field.
+ * When pluginRoot is set (e.g. "plugins"), source is a short name (e.g. "my-plugin")
+ * and resolves to rootDir/plugins/my-plugin.
+ */
+export function resolvePluginDir(rootDir: string, source: string, pluginRoot?: string): string {
+  if (pluginRoot) {
+    return path.resolve(rootDir, pluginRoot, source);
+  }
+  // source is like "./plugins/code-review" or "./skills"
   return path.resolve(rootDir, source);
 }
 
 /**
  * Scan a single plugin directory.
  * Plugin structure has skills/agents/commands/hooks directly in root (not under .claude/).
+ * Respects custom resource paths from plugin.json when available.
  */
 export function scanPlugin(pluginDir: string, meta?: PluginMeta): PluginScanResult {
   // Read plugin.json for metadata if not provided
   const resolvedMeta = meta || readPluginMeta(pluginDir);
 
+  // Resolve resource paths: use custom paths from meta if available, fallback to defaults
+  const skillsDir = resolvedMeta.skills
+    ? path.resolve(pluginDir, resolvedMeta.skills)
+    : path.join(pluginDir, 'skills');
+
+  const agentsDir = resolvedMeta.agents
+    ? path.resolve(pluginDir, resolvedMeta.agents as string)
+    : path.join(pluginDir, 'agents');
+
+  const commandsPath = resolvedMeta.commands;
+  const commandsDir = typeof commandsPath === 'string' && !commandsPath.endsWith('.md')
+    ? path.resolve(pluginDir, commandsPath)
+    : path.join(pluginDir, 'commands');
+
+  const hooksPath = resolvedMeta.hooks
+    ? path.resolve(pluginDir, resolvedMeta.hooks)
+    : path.join(pluginDir, 'hooks', 'hooks.json');
+
+  // MCP: use custom path from meta, fallback to .mcp.json in plugin root
+  const mcpPath = resolvedMeta.mcpServers
+    ? path.resolve(pluginDir, resolvedMeta.mcpServers)
+    : path.join(pluginDir, '.mcp.json');
+  const mcpConfig = scanMCPJson(mcpPath);
+
+  // Scan plugin-level resource files referenced by MCP config (e.g. scripts/)
+  const pluginFiles = scanMCPReferencedFiles(pluginDir, mcpConfig);
+
   return {
     meta: resolvedMeta,
-    skills: scanSkillsDir(path.join(pluginDir, 'skills')),
-    instructions: [], // Plugins don't have CLAUDE.md
-    mcp: null, // Plugins don't have .mcp.json
-    agents: scanAgentsDir(path.join(pluginDir, 'agents')),
-    commands: scanCommandsDir(path.join(pluginDir, 'commands')),
-    hooks: scanHooksJson(path.join(pluginDir, 'hooks', 'hooks.json')),
+    skills: scanSkillsDir(skillsDir),
+    instructions: [],
+    mcp: mcpConfig,
+    agents: scanAgentsDir(agentsDir),
+    commands: scanCommandsDir(commandsDir),
+    hooks: scanHooksJson(hooksPath),
+    pluginFiles,
     rootDir: pluginDir,
   };
 }
 
 /**
  * Read plugin.json metadata from a plugin directory.
+ * Extracts both metadata fields and resource path overrides.
  */
-function readPluginMeta(pluginDir: string): PluginMeta {
+export function readPluginMeta(pluginDir: string): PluginMeta {
   const pluginJsonPath = path.join(pluginDir, '.claude-plugin', 'plugin.json');
   const content = readFile(pluginJsonPath);
   if (!content) {
@@ -86,7 +137,7 @@ function readPluginMeta(pluginDir: string): PluginMeta {
 
   try {
     const data = JSON.parse(content);
-    return {
+    const meta: PluginMeta = {
       name: data.name || path.basename(pluginDir),
       description: data.description,
       version: data.version,
@@ -97,24 +148,151 @@ function readPluginMeta(pluginDir: string): PluginMeta {
       license: data.license,
       keywords: data.keywords,
     };
+
+    // Resource path overrides
+    if (data.skills) meta.skills = data.skills;
+    if (data.agents) meta.agents = data.agents;
+    if (data.commands) meta.commands = data.commands;
+    if (data.hooks) meta.hooks = data.hooks;
+    if (data.mcpServers) meta.mcpServers = data.mcpServers;
+    if (data.apps) meta.apps = data.apps;
+
+    // Marketplace display metadata
+    if (data.interface) meta.interface = data.interface;
+
+    return meta;
   } catch {
     return { name: path.basename(pluginDir) };
   }
 }
 
 /**
+ * Extract file/directory paths referenced by ${CLAUDE_PLUGIN_ROOT} in MCP config,
+ * then scan those paths recursively and return as PluginResourceFile[].
+ */
+function scanMCPReferencedFiles(pluginDir: string, mcp: MCPConfig | null): PluginResourceFile[] {
+  if (!mcp) return [];
+  const referencedDirs = new Set<string>();
+
+  for (const server of mcp.servers) {
+    // Extract from args
+    for (const arg of server.args || []) {
+      const matches = arg.matchAll(/\$\{CLAUDE_PLUGIN_ROOT\}\/([^\s"]+)/g);
+      for (const m of matches) {
+        referencedDirs.add(m[1].split('/')[0]);
+      }
+    }
+    // Extract from env values
+    for (const val of Object.values(server.env || {})) {
+      const matches = val.matchAll(/\$\{CLAUDE_PLUGIN_ROOT\}\/([^\s"]+)/g);
+      for (const m of matches) {
+        referencedDirs.add(m[1].split('/')[0]);
+      }
+    }
+  }
+
+  const files: PluginResourceFile[] = [];
+  for (const dirName of referencedDirs) {
+    const dirPath = path.join(pluginDir, dirName);
+    if (!fileExists(dirPath)) continue;
+    for (const file of listFilesRecursive(dirPath)) {
+      const content = readFile(file);
+      if (content !== null) {
+        files.push({
+          relativePath: path.relative(pluginDir, file).replace(/\\/g, '/'),
+          content,
+        });
+      }
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Analyze what a marketplace source directory contains.
+ *
+ * Priority:
+ * 1. Has .claude-plugin/plugin.json → plugin root (most explicit)
+ * 2. Has skills/ or agents/ subdirectory → plugin root (standard layout)
+ * 3. Directory name matches "skills"/"agents"/"commands" → direct resource dir
+ * 4. Subdirectories contain SKILL.md → skills directory (content detection)
+ * 5. None of the above → unknown, treat as plugin root
+ */
+type SourceTargetType = 'plugin-root' | 'skills-dir' | 'agents-dir' | 'commands-dir' | 'unknown';
+
+export function analyzeSourceTarget(dir: string): SourceTargetType {
+  // Has .claude-plugin/plugin.json → explicit plugin root
+  if (fileExists(path.join(dir, '.claude-plugin', 'plugin.json'))) return 'plugin-root';
+
+  // Has skills/ or agents/ subdirectory → standard plugin root layout
+  if (fileExists(path.join(dir, 'skills')) || fileExists(path.join(dir, 'agents'))) return 'plugin-root';
+
+  // Infer resource type from directory name
+  const dirName = path.basename(dir).toLowerCase();
+  if (dirName === 'skills') return 'skills-dir';
+  if (dirName === 'agents') return 'agents-dir';
+  if (dirName === 'commands') return 'commands-dir';
+
+  // Content detection: subdirectories contain SKILL.md → skills directory
+  const subdirs = listDirs(dir);
+  for (const sub of subdirs) {
+    if (fileExists(path.join(sub, 'SKILL.md'))) return 'skills-dir';
+  }
+
+  return 'unknown';
+}
+
+/**
  * Scan all plugins in a marketplace repo.
- * Returns an array of PluginScanResult, one per plugin.
+ * Analyzes each source target to determine if it's a plugin root or a direct
+ * resource directory, then routes to the appropriate scanning strategy.
  */
 export function scanAllPlugins(rootDir: string): PluginScanResult[] {
-  const metas = scanMarketplace(rootDir);
+  const marketplace = scanMarketplaceMeta(rootDir);
+  if (!marketplace) return [];
+
+  const pluginRoot = marketplace.metadata?.pluginRoot;
   const results: PluginScanResult[] = [];
 
-  for (const meta of metas) {
-    if (!meta.source) continue;
-    const pluginDir = resolvePluginDir(rootDir, meta.source);
+  for (const entry of marketplace.plugins) {
+    if (!entry.source) continue;
+    const pluginDir = resolvePluginDir(rootDir, entry.source, pluginRoot);
     if (!fileExists(pluginDir)) continue;
-    const result = scanPlugin(pluginDir, meta);
+
+    const meta: PluginMeta = {
+      name: entry.name,
+      description: entry.description,
+      version: entry.version,
+      source: entry.source,
+      category: entry.category,
+    };
+
+    const targetType = analyzeSourceTarget(pluginDir);
+    let result: PluginScanResult;
+
+    switch (targetType) {
+      case 'skills-dir':
+        result = {
+          meta, skills: scanSkillsDir(pluginDir),
+          instructions: [], mcp: null, agents: [], commands: [], hooks: null, pluginFiles: [], rootDir: pluginDir,
+        };
+        break;
+      case 'agents-dir':
+        result = {
+          meta, agents: scanAgentsDir(pluginDir),
+          skills: [], instructions: [], mcp: null, commands: [], hooks: null, pluginFiles: [], rootDir: pluginDir,
+        };
+        break;
+      case 'commands-dir':
+        result = {
+          meta, commands: scanCommandsDir(pluginDir),
+          skills: [], instructions: [], mcp: null, agents: [], hooks: null, pluginFiles: [], rootDir: pluginDir,
+        };
+        break;
+      default: // 'plugin-root' | 'unknown'
+        result = scanPlugin(pluginDir, meta);
+    }
 
     // Only include plugins that have actual resources
     const resourceCount = result.skills.length + result.agents.length +
@@ -125,6 +303,17 @@ export function scanAllPlugins(rootDir: string): PluginScanResult[] {
   }
 
   return results;
+}
+
+/**
+ * Scan marketplace and return full MarketplaceScanResult with metadata.
+ */
+export function scanMarketplaceFull(rootDir: string): MarketplaceScanResult | null {
+  const marketplace = scanMarketplaceMeta(rootDir);
+  if (!marketplace) return null;
+
+  const plugins = scanAllPlugins(rootDir);
+  return { marketplace, plugins };
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,20 @@
 // Target platforms
 export type Platform = 'codex' | 'opencode' | 'cursor' | 'antigravity';
 
+// --- Platform resource paths (single source of truth) ---
+// These must match the actual output paths in each platform's writer/converter.
+
+export interface PlatformPaths {
+  pluginJson: string;           // manifest output path
+  marketplaceJson?: string;     // marketplace output path
+  skills?: string;              // skills directory reference
+  agents?: string;              // agents directory reference
+  commands?: string;            // commands directory reference
+  instructions?: string;        // instructions file reference
+  mcp?: string;                 // MCP config reference
+  hooks?: string;               // hooks config reference
+}
+
 // --- Skill ---
 export interface SkillFrontmatter {
   name?: string;
@@ -101,12 +115,30 @@ export interface Hooks {
   [event: string]: HookMatcher[];
 }
 
+// --- Plugin Interface (Marketplace display metadata) ---
+export interface PluginInterface {
+  displayName?: string;
+  shortDescription?: string;
+  longDescription?: string;
+  developerName?: string;
+  category?: string;
+  capabilities?: string[];
+  websiteURL?: string;
+  privacyPolicyURL?: string;
+  termsOfServiceURL?: string;
+  defaultPrompt?: string[];
+  brandColor?: string;
+  composerIcon?: string;
+  logo?: string;
+  screenshots?: string[];
+}
+
 // --- Plugin ---
 export interface PluginMeta {
   name: string;
   description?: string;
   version?: string;
-  author?: { name: string; email?: string };
+  author?: { name: string; email?: string; url?: string };
   source?: string;
   category?: string;
   displayName?: string;
@@ -114,6 +146,39 @@ export interface PluginMeta {
   repository?: string;
   license?: string;
   keywords?: string[];
+  // Resource path overrides (from plugin.json)
+  skills?: string;
+  agents?: string;
+  commands?: string | string[];
+  hooks?: string;
+  mcpServers?: string;
+  apps?: string;
+  // Marketplace display metadata
+  interface?: PluginInterface;
+}
+
+// --- Marketplace ---
+export interface MarketplaceMeta {
+  name: string;
+  version?: string;
+  description?: string;
+  owner?: { name: string; email?: string };
+  metadata?: { description?: string; version?: string; pluginRoot?: string };
+  plugins: MarketplacePluginEntry[];
+}
+
+export interface MarketplacePluginEntry {
+  name: string;
+  source: string;
+  description?: string;
+  version?: string;
+  category?: string;
+}
+
+// --- Plugin Resource File ---
+export interface PluginResourceFile {
+  relativePath: string;  // relative to plugin root, e.g. "scripts/mcp-server/start.js"
+  content: string;
 }
 
 // --- Scan Result ---
@@ -124,6 +189,7 @@ export interface ScanResult {
   agents: Agent[];
   commands: Command[];
   hooks: Hooks | null;
+  pluginFiles: PluginResourceFile[];  // plugin-level resource files (scripts/, etc.)
   rootDir: string;
 }
 
@@ -131,11 +197,16 @@ export interface PluginScanResult extends ScanResult {
   meta: PluginMeta;
 }
 
+export interface MarketplaceScanResult {
+  marketplace: MarketplaceMeta;
+  plugins: PluginScanResult[];
+}
+
 // --- Convert Result ---
 export interface ConvertedFile {
   path: string;
   content: string;
-  type: 'skill' | 'instruction' | 'mcp' | 'agent' | 'command' | 'hook';
+  type: 'skill' | 'instruction' | 'mcp' | 'agent' | 'command' | 'hook' | 'manifest' | 'resource';
 }
 
 export interface ConvertResult {

--- a/src/writer/antigravity.ts
+++ b/src/writer/antigravity.ts
@@ -40,6 +40,11 @@ export function generateAntigravity(scan: ScanResult): ConvertResult {
     warnings.push(...hookResult.warnings);
   }
 
+  // Plugin-level resource files (scripts/, etc. referenced by MCP)
+  for (const pf of scan.pluginFiles) {
+    files.push({ path: pf.relativePath, content: pf.content, type: 'resource' });
+  }
+
   return {
     platform: 'antigravity',
     files,

--- a/src/writer/codex.ts
+++ b/src/writer/codex.ts
@@ -1,11 +1,11 @@
-import * as path from 'path';
-import type { ScanResult, ConvertedFile, ConvertResult } from '../types.js';
+import type { ScanResult, ConvertedFile, ConvertResult, PluginScanResult } from '../types.js';
 import { convertSkill, convertSkillCodexYaml, convertSkillAuxFiles } from '../converter/skill.js';
 import { mergeInstructions } from '../converter/instructions.js';
 import { convertMCP } from '../converter/mcp.js';
 import { convertAgent } from '../converter/agent.js';
 import { convertCommand } from '../converter/command.js';
 import { convertHooks } from '../converter/hooks.js';
+import { convertPluginManifestForCodex } from '../converter/pluginManifest.js';
 
 export function generateCodex(scan: ScanResult): ConvertResult {
   const files: ConvertedFile[] = [];
@@ -54,6 +54,17 @@ export function generateCodex(scan: ScanResult): ConvertResult {
         files.push({ path: 'AGENTS.md', content: hookContent.trim(), type: 'hook' });
       }
     }
+  }
+
+  // Plugin-level resource files (scripts/, etc. referenced by MCP)
+  for (const pf of scan.pluginFiles) {
+    files.push({ path: pf.relativePath, content: pf.content, type: 'resource' });
+  }
+
+  // Generate .codex-plugin/plugin.json manifest
+  const meta = (scan as PluginScanResult).meta;
+  if (meta) {
+    files.push(convertPluginManifestForCodex(scan, meta));
   }
 
   return {

--- a/src/writer/cursor.ts
+++ b/src/writer/cursor.ts
@@ -5,6 +5,8 @@ import { convertMCP } from '../converter/mcp.js';
 import { convertAgent } from '../converter/agent.js';
 import { convertCommand } from '../converter/command.js';
 import { convertHooks } from '../converter/hooks.js';
+// TODO: re-enable after Cursor plugin manifest test validation
+// import { convertPluginManifestForCursor } from '../converter/pluginManifest.js';
 
 export function generateCursor(scan: ScanResult): ConvertResult {
   const files: ConvertedFile[] = [];
@@ -41,9 +43,14 @@ export function generateCursor(scan: ScanResult): ConvertResult {
     warnings.push(...hookResult.warnings);
   }
 
-  // Generate .cursor-plugin/plugin.json
-  const pluginJson = generatePluginJson(scan);
-  files.push(pluginJson);
+  // Plugin-level resource files (scripts/, etc. referenced by MCP)
+  for (const pf of scan.pluginFiles) {
+    files.push({ path: pf.relativePath, content: pf.content, type: 'resource' });
+  }
+
+  // TODO: Cursor plugin manifest generation — pending test validation
+  // const meta = (scan as PluginScanResult).meta;
+  // files.push(convertPluginManifestForCursor(scan, meta));
 
   // Remap paths: .cursor/xxx → plugin format (skills/, agents/, etc.)
   for (const file of files) {
@@ -51,41 +58,6 @@ export function generateCursor(scan: ScanResult): ConvertResult {
   }
 
   return { platform: 'cursor', files, warnings };
-}
-
-/**
- * Generate .cursor-plugin/plugin.json manifest.
- */
-function generatePluginJson(scan: ScanResult): ConvertedFile {
-  const meta = (scan as PluginScanResult).meta;
-  const manifest: Record<string, unknown> = {
-    name: meta?.name || 'converted-plugin',
-  };
-
-  if (meta?.displayName) manifest.displayName = meta.displayName;
-
-  manifest.description = meta?.description || 'Converted from Claude Code plugin via acplugin';
-  manifest.version = meta?.version || '1.0.0';
-
-  if (meta?.author) manifest.author = meta.author;
-  if (meta?.homepage) manifest.homepage = meta.homepage;
-  if (meta?.repository) manifest.repository = meta.repository;
-  if (meta?.license) manifest.license = meta.license;
-  if (meta?.keywords) manifest.keywords = meta.keywords;
-
-  // Only include paths for components that exist
-  if (scan.skills.length > 0) manifest.skills = './skills/';
-  if (scan.agents.length > 0) manifest.agents = './agents/';
-  if (scan.commands.length > 0) manifest.commands = './commands/';
-  if (scan.instructions.length > 0) manifest.rules = './rules/';
-  if (scan.mcp) manifest.mcpServers = './mcp.json';
-  if (scan.hooks) manifest.hooks = './hooks/hooks-cursor.json';
-
-  return {
-    path: '.cursor-plugin/plugin.json',
-    content: JSON.stringify(manifest, null, 2),
-    type: 'instruction',
-  };
 }
 
 /**

--- a/src/writer/opencode.ts
+++ b/src/writer/opencode.ts
@@ -51,6 +51,11 @@ export function generateOpenCode(scan: ScanResult): ConvertResult {
     }
   }
 
+  // Plugin-level resource files (scripts/, etc. referenced by MCP)
+  for (const pf of scan.pluginFiles) {
+    files.push({ path: pf.relativePath, content: pf.content, type: 'resource' });
+  }
+
   return {
     platform: 'opencode',
     files: files.filter(f => !f.path.includes('.hook-')),


### PR DESCRIPTION
 ## 概要

  - 新增 Codex 平台的 `.codex-plugin/plugin.json` 和 `.agents/plugins/marketplace.json` 生成
  - 修复插件 Scanner 多项缺陷：MCP 扫描、自定义路径、source 语义分析
  - MCP 配置中 `${CLAUDE_PLUGIN_ROOT}` 环境变量自动转换为相对路径
  - 插件级资源文件（如 `scripts/`）随 MCP 引用自动复制到输出
  - GitHub 下载改用 `git clone --recurse-submodules`，支持 submodule 仓库

  ## 变更详情

  ### 1. Codex 插件 manifest 生成
  - 新增 `src/converter/pluginManifest.ts`，统一管理 `PLATFORM_PATHS` 路径映射
  - 生成 `.codex-plugin/plugin.json`（含 interface 展示元数据）
  - 生成 `.agents/plugins/marketplace.json`（含 policy 默认值）
  - Cursor 版本代码已编写但暂时注释，待独立测试后启用

  ### 2. Scanner 修复与增强
  - **MCP 扫描**：`scanPlugin()` 不再硬编码 `mcp: null`，根据 `meta.mcpServers` 或默认 `.mcp.json` 扫描
  - **自定义路径**：`readPluginMeta()` 提取 `skills/agents/hooks/mcpServers` 路径字段，`scanPlugin()`
  使用自定义路径替代硬编码
  - **pluginRoot 支持**：`scanMarketplace()` 处理 `metadata.pluginRoot` 前缀
  - **source 语义分析**：新增 `analyzeSourceTarget()` 智能判断 marketplace source 指向插件根目录还是资源目录（如
  `source: "./skills"`）

  ### 3. MCP 环境变量转换
  - 新增 `transformPluginRootPaths()`，将 `${CLAUDE_PLUGIN_ROOT}/scripts/...` 转换为 `./scripts/...`
  - 四个平台（Codex/Cursor/OpenCode/Antigravity）的 `args` 和 `env` 均已适配

  ### 4. 插件级资源文件复制
  - 新增 `scanMCPReferencedFiles()`，从 MCP 的 `args`/`env` 中提取 `${CLAUDE_PLUGIN_ROOT}` 引用的目录并递归扫描
  - 四个 Writer 均输出 `pluginFiles` 到目标目录

  ### 5. Git clone 替代 tarball
  - 优先使用 `git clone --depth 1 --recurse-submodules`，正确拉取 submodule
  - git 不可用时回退到原有 tarball 下载